### PR TITLE
Update utils.js

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,7 +23,7 @@ const buildValidFormatFunc = map(({ start, end }) => {
   return allPass([ startsWith(start), endsWith(end) ]);
 });
 
-const domainRegTest = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9]$)/;
+const domainRegTest = /^(?:[A-Za-z0-9-]{0,61}[A-Za-z0-9]$)/;
 const checkDomainTest = domainRegTest.test.bind(domainRegTest);
 
 const isDomainMatch = curry((toCheck, base) => {


### PR DESCRIPTION
I think,

```
const domainRegTest = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9]$)/;
```

should be

```
const domainRegTest = /^(?:[A-Za-z0-9-]{0,61}[A-Za-z0-9]$)/;
```

to support 'm.xxx.com'